### PR TITLE
chore: bump layertwo/cloudnative-pgvecto.rs to 16.8

### DIFF
--- a/containers/cloudnative-pgvecto.rs/versions.yml
+++ b/containers/cloudnative-pgvecto.rs/versions.yml
@@ -1,6 +1,6 @@
 cnpg:
   # renovate: datasource=docker depName=ghcr.io/cloudnative-pg/postgresql
-  - "16.6"
+  - "16.8"
 pgvectors:
   # renovate: datasource=github-releases depName=tensorchord/pgvecto.rs
   - "v0.3.0"


### PR DESCRIPTION
Renovate was reporting that 16.6 was unsupported, so manually updated to 16.8.