### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/cloudflare-ddns-docker-image.yml
+++ b/.github/workflows/cloudflare-ddns-docker-image.yml
@@ -19,6 +19,8 @@ jobs:
 
   build-and-test:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     defaults:
       run:
         working-directory: ./containers/cloudflare-ddns


### PR DESCRIPTION
Potential fix for [https://github.com/layertwo/homelab/security/code-scanning/1](https://github.com/layertwo/homelab/security/code-scanning/1)

In general, the problem is fixed by explicitly declaring a `permissions` block either at the workflow root or per job, and scoping the `GITHUB_TOKEN` to the minimum needed. In this workflow, the `package` job already has scoped permissions, but the `build-and-test` job does not, so it inherits broader defaults.

The best minimal fix without changing existing functionality is to add a `permissions` block to the `build-and-test` job that limits access to `contents: read`. This is sufficient for `actions/checkout` to function. No other scopes are needed, since the job doesn’t push commits, create releases, or modify issues/PRs. We do not need to touch the `package` job’s permissions, as they are already explicitly defined and appropriate for building and pushing images. Concretely, in `.github/workflows/cloudflare-ddns-docker-image.yml`, under `build-and-test:` and alongside `runs-on`, add:

```yaml
    permissions:
      contents: read
```

leaving indentation consistent with the existing YAML structure.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
