### PR TITLE
feat(forgejo): add Actions runner

### DIFF
--- a/clusters/home/apps/development/forgejo/app/release.yml
+++ b/clusters/home/apps/development/forgejo/app/release.yml
@@ -62,6 +62,8 @@ spec:
       config:
         database:
           DB_TYPE: postgres
+        actions:
+          ENABLED: true
         indexer:
           ISSUE_INDEXER_TYPE: bleve
           REPO_INDEXER_ENABLED: true

--- a/clusters/home/apps/development/forgejo/runner/kustomization.yml
+++ b/clusters/home/apps/development/forgejo/runner/kustomization.yml
@@ -2,8 +2,5 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
-  - namespace.yml
-  - postgres/
-  - valkey/
-  - app/
-  - runner/
+  - secrets-forgejo-runner.sops.yml
+  - release.yml

--- a/clusters/home/apps/development/forgejo/runner/release.yml
+++ b/clusters/home/apps/development/forgejo/runner/release.yml
@@ -1,0 +1,155 @@
+---
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: forgejo-runner
+  namespace: forgejo
+spec:
+  interval: 30m
+  chart:
+    spec:
+      chart: app-template
+      version: 4.6.2
+      sourceRef:
+        kind: HelmRepository
+        name: bjw-s
+        namespace: flux-system
+  install:
+    remediation:
+      retries: 3
+  upgrade:
+    cleanupOnFail: true
+    remediation:
+      strategy: rollback
+      retries: 3
+  values:
+    controllers:
+      main:
+        type: statefulset
+        replicas: 2
+        pod:
+          annotations:
+            reloader.stakater.com/auto: "true"
+        initContainers:
+          register:
+            image:
+              repository: code.forgejo.org/forgejo/runner
+              tag: 12.7.3
+            command:
+              - /bin/bash
+              - -c
+            args:
+              - |
+                while : ; do
+                  forgejo-runner register \
+                    --no-interactive \
+                    --token $(RUNNER_TOKEN) \
+                    --name $(RUNNER_NAME) \
+                    --instance $(RUNNER_INSTANCE) && break ;
+                  sleep 1 ;
+                done ;
+                forgejo-runner generate-config > /data/config.yml ;
+                sed -i -e "s|network: .*|network: host|" /data/config.yml ;
+                sed -i -e "s|^  envs:$|  envs:\n    DOCKER_HOST: tcp://localhost:2376\n    DOCKER_TLS_VERIFY: 1\n    DOCKER_CERT_PATH: /certs/client|" /data/config.yml ;
+                sed -i -e "s|^  options:|  options: -v /certs/client:/certs/client|" /data/config.yml ;
+                sed -i -e "s|  valid_volumes: \[\]$|  valid_volumes:\n    - /certs/client|" /data/config.yml ;
+                sed -i -e "s|  labels: \[\]$|  labels:\n    - \"ubuntu-latest:docker://ghcr.io/catthehacker/ubuntu:act-24.04\"\n    - \"ubuntu-24.04:docker://ghcr.io/catthehacker/ubuntu:act-24.04\"|" /data/config.yml
+            env:
+              RUNNER_NAME:
+                valueFrom:
+                  fieldRef:
+                    fieldPath: metadata.name
+            envFrom:
+              - secretRef:
+                  name: secrets-forgejo-runner
+            securityContext:
+              allowPrivilegeEscalation: false
+              capabilities:
+                drop:
+                  - ALL
+              privileged: false
+              readOnlyRootFilesystem: true
+              runAsNonRoot: true
+              seccompProfile:
+                type: RuntimeDefault
+        containers:
+          runner:
+            image:
+              repository: code.forgejo.org/forgejo/runner
+              tag: 12.7.3
+            command:
+              - /bin/bash
+              - -c
+            args:
+              - |
+                while ! nc -z localhost 2376 </dev/null ; do
+                  echo 'waiting for docker daemon...' ;
+                  sleep 5 ;
+                done ;
+                forgejo-runner --config /data/config.yml daemon
+            env:
+              DOCKER_HOST:
+                value: tcp://localhost:2376
+              DOCKER_CERT_PATH:
+                value: /certs/client
+              DOCKER_TLS_VERIFY:
+                value: "1"
+            securityContext:
+              allowPrivilegeEscalation: false
+              capabilities:
+                drop:
+                  - ALL
+              privileged: false
+              readOnlyRootFilesystem: true
+              runAsNonRoot: true
+              seccompProfile:
+                type: RuntimeDefault
+            resources:
+              requests:
+                memory: 64Mi
+                cpu: 100m
+              limits:
+                memory: 4Gi
+                cpu: "1"
+          dind:
+            image:
+              repository: docker
+              tag: 29.3.1-dind
+            env:
+              DOCKER_TLS_CERTDIR:
+                value: /certs
+            securityContext:
+              privileged: true
+            resources:
+              requests:
+                memory: 128Mi
+                cpu: 100m
+              limits:
+                memory: 4Gi
+                cpu: "1"
+
+    persistence:
+      runner-data:
+        type: emptyDir
+        globalMounts:
+          - path: /data
+      docker-certs:
+        type: emptyDir
+        globalMounts:
+          - path: /certs
+      tmp:
+        type: emptyDir
+        advancedMounts:
+          main:
+            runner:
+              - path: /tmp
+
+    affinity:
+      podAntiAffinity:
+        preferredDuringSchedulingIgnoredDuringExecution:
+          - weight: 100
+            podAffinityTerm:
+              topologyKey: kubernetes.io/hostname
+              labelSelector:
+                matchLabels:
+                  app.kubernetes.io/name: forgejo-runner

--- a/clusters/home/apps/development/forgejo/runner/secrets-forgejo-runner.sops.yml
+++ b/clusters/home/apps/development/forgejo/runner/secrets-forgejo-runner.sops.yml
@@ -1,0 +1,24 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: secrets-forgejo-runner
+  namespace: forgejo
+type: Opaque
+stringData:
+  RUNNER_INSTANCE: ENC[AES256_GCM,data:dHnr0XmCPFRJFXG+jSbsu6w1r6J7JVnLFA==,iv:Tv2KAcAqS9GSbwd/6ppBOjSqYx0AP+qWTCFlEjKjrrg=,tag:SziWIcG3nGZ7Lv2Rb3d6yg==,type:str]
+  RUNNER_TOKEN: ENC[AES256_GCM,data:KjyxxKtmsDepKVAmddfbMzEAeYvCqie6bRYFS/O190y1yAo+1nJLmxvS0A==,iv:dQohENA6dzRhqQZSTdV5Bk4uTJKKsAzSQ+Nw+tkP7Zg=,tag:bHL8hXGyxZ5NXdN7xrJVZw==,type:str]
+sops:
+  age:
+    - recipient: age140p5gj8xeqccpu283eycwhq7kwjrwug9emmj5mucn4j80jjzfd6qsnuv3y
+      enc: |
+        -----BEGIN AGE ENCRYPTED FILE-----
+        YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBFUGYzdVBWREd3YkNEcjFa
+        L2U1NDNsQ2x6VWhhVitRd05udzdHejVlRVVzClhJV0d4L0JYUk1DSVpCT2JOc3Jr
+        bmpkYTl5aEo3Y1hNRlFkSkZqNlhraFUKLS0tIElyQy9NQm9NZGorMFVGd0svb2Fm
+        OXlQa1lDZCtuK1g4T1VGZ0dOUHQwaWcK1/H2/pDFoymgLC35yx2lPN0NaYG879gM
+        3iO/UNpc7wbeidP7HU5o3O+AAxyenuw9AT0oYOEiE64IJf2OZeA9PA==
+        -----END AGE ENCRYPTED FILE-----
+  lastmodified: "2026-03-31T02:10:16Z"
+  mac: ENC[AES256_GCM,data:kwmssPblij1cU18rujKJUpn1KKmxkiQVqCaOUag9fEdT0rKlCvbELPssfQk6IS4b6XN+BdyCyfd15BIoL+OmSYFFrs2fu/8w0BZTtN7Opq7Ldc4USfkLVOryue1UHZ5EnBcB2Qcz0r+Wvbhxp4uZT4DtT5sLlHoWjQ8FY5YrnOU=,iv:SdPOUezm3jFMzV7IeVY1J7+TYiLlxhijlN/8Xlknecc=,tag:DqVPG6YNL3sGNwdY8aNzXg==,type:str]
+  encrypted_regex: ^(data|stringData)$
+  version: 3.12.2


### PR DESCRIPTION
- StatefulSet with 2 replicas (stable pod names per runner)
- DinD sidecar with TLS for container-based job execution
- Init container registers runner on first start, regenerates config on restart
- Hardened security contexts: non-root, read-only FS, drop all caps (runner)
- Only DinD container is privileged
- Labels: ubuntu-latest and ubuntu-24.04 via catthehacker/ubuntu:act-24.04
- Enable Actions in Forgejo config