### PR TITLE
feat: add hermes-agent container build

### DIFF
--- a/.github/workflows/hermes-agent-docker-image.yml
+++ b/.github/workflows/hermes-agent-docker-image.yml
@@ -1,0 +1,70 @@
+name: hermes-agent
+
+on:
+  workflow_dispatch:
+  push:
+    branches: [ "mainline" ]
+    paths:
+      - containers/hermes-agent/**
+      - .github/workflows/hermes-agent-docker-image.yml
+  pull_request:
+    branches: [ "mainline" ]
+    paths:
+      - containers/hermes-agent/**
+      - .github/workflows/hermes-agent-docker-image.yml
+
+env:
+  REGISTRY: ghcr.io
+
+jobs:
+  package:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+      id-token: write
+
+    steps:
+      - uses: actions/checkout@v6
+
+      - id: ver
+        name: Read upstream ref
+        run: |
+          REF=$(yq '.ref' containers/hermes-agent/version.yaml)
+          echo "ref=${REF}" >> "$GITHUB_OUTPUT"
+
+      - name: Install cosign
+        if: github.event_name != 'pull_request'
+        uses: sigstore/cosign-installer@6f9f17788090df1f26f669e9d70d6ae9567deba6 # v4.1.2
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd # v4.0.0
+
+      - name: Log into registry ${{ env.REGISTRY }}
+        if: github.event_name != 'pull_request'
+        uses: docker/login-action@4907a6ddec9925e35a0a9e82d7399ccc52663121 # v4.1.0
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build and push Docker image
+        id: build-and-push
+        uses: docker/build-push-action@bcafcacb16a39f128d818304e6c9c0c18556b85f # v7.1.0
+        with:
+          context: containers/hermes-agent
+          push: ${{ github.event_name != 'pull_request' }}
+          build-args: |
+            HERMES_REF=${{ steps.ver.outputs.ref }}
+          tags: |
+            ghcr.io/layertwo/hermes-agent:latest
+            ghcr.io/layertwo/hermes-agent:${{ steps.ver.outputs.ref }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+
+      - name: Sign the published Docker image
+        if: ${{ github.event_name != 'pull_request' }}
+        env:
+          DIGEST: ${{ steps.build-and-push.outputs.digest }}
+        run: |
+          cosign sign --yes ghcr.io/layertwo/hermes-agent@${DIGEST}

--- a/containers/hermes-agent/Dockerfile
+++ b/containers/hermes-agent/Dockerfile
@@ -1,0 +1,84 @@
+# syntax=docker/dockerfile:1.7
+
+ARG HERMES_REF=v2026.4.30
+
+# ---------- Source fetch ----------
+# renovate: datasource=docker depName=alpine/git
+FROM alpine/git:2.52.0 AS src
+ARG HERMES_REF
+RUN git clone --depth=1 --branch ${HERMES_REF} \
+    https://github.com/NousResearch/hermes-agent /src
+
+# ---------- Pinned tool images (copy-only) ----------
+# renovate: datasource=docker depName=node
+FROM node:24.15.0-trixie-slim AS node
+# renovate: datasource=docker depName=ghcr.io/astral-sh/uv
+FROM ghcr.io/astral-sh/uv:0.11.11 AS uv
+
+# ---------- Build stage ----------
+# renovate: datasource=docker depName=python
+FROM python:3.14.4-slim-trixie AS build
+
+ENV PYTHONUNBUFFERED=1 \
+    PLAYWRIGHT_BROWSERS_PATH=/opt/hermes/.playwright \
+    npm_config_install_links=false \
+    PATH="/opt/hermes/.venv/bin:${PATH}"
+
+RUN apt-get update && apt-get install -y --no-install-recommends \
+        ca-certificates \
+        build-essential gcc python3-dev libffi-dev \
+        git \
+    && rm -rf /var/lib/apt/lists/*
+
+COPY --from=node /usr/local/bin/node /usr/local/bin/node
+COPY --from=node /usr/local/lib/node_modules /usr/local/lib/node_modules
+RUN ln -sf /usr/local/lib/node_modules/npm/bin/npm-cli.js /usr/local/bin/npm \
+ && ln -sf /usr/local/lib/node_modules/npm/bin/npx-cli.js /usr/local/bin/npx
+
+COPY --from=uv /uv /uvx /usr/local/bin/
+
+WORKDIR /opt/hermes
+COPY --from=src /src /opt/hermes
+
+RUN npm install --prefer-offline --no-audit \
+ && (cd web && npm install --prefer-offline --no-audit) \
+ && (cd ui-tui && npm install --prefer-offline --no-audit) \
+ && npm cache clean --force
+
+RUN cd web && npm run build && cd ../ui-tui && npm run build
+
+RUN uv venv && uv pip install --no-cache-dir -e ".[all]"
+
+RUN npx playwright install --with-deps chromium --only-shell
+
+# ---------- Runtime stage ----------
+# renovate: datasource=docker depName=python
+FROM python:3.14.4-slim-trixie
+
+ENV PYTHONUNBUFFERED=1 \
+    PLAYWRIGHT_BROWSERS_PATH=/opt/hermes/.playwright \
+    HERMES_WEB_DIST=/opt/hermes/hermes_cli/web_dist \
+    HERMES_HOME=/opt/data \
+    PATH="/opt/hermes/.venv/bin:/opt/data/.local/bin:${PATH}"
+
+RUN apt-get update && apt-get install -y --no-install-recommends \
+        ca-certificates tini ffmpeg ripgrep git openssh-client procps \
+        libnss3 libnspr4 libatk1.0-0 libatk-bridge2.0-0 libcups2 \
+        libxkbcommon0 libxcomposite1 libxdamage1 libxfixes3 libxrandr2 \
+        libgbm1 libpango-1.0-0 libcairo2 libasound2 libatspi2.0-0 \
+    && rm -rf /var/lib/apt/lists/* \
+    && useradd -u 10000 -m -d /opt/data hermes
+
+COPY --from=node /usr/local/bin/node /usr/local/bin/node
+COPY --from=node /usr/local/lib/node_modules /usr/local/lib/node_modules
+RUN ln -sf /usr/local/lib/node_modules/npm/bin/npm-cli.js /usr/local/bin/npm \
+ && ln -sf /usr/local/lib/node_modules/npm/bin/npx-cli.js /usr/local/bin/npx
+
+COPY --from=build --chown=10000:10000 /opt/hermes /opt/hermes
+
+WORKDIR /opt/hermes
+USER 10000
+VOLUME ["/opt/data"]
+
+ENTRYPOINT ["/usr/bin/tini", "-g", "--", "hermes"]
+CMD ["gateway", "run"]

--- a/containers/hermes-agent/version.yaml
+++ b/containers/hermes-agent/version.yaml
@@ -1,0 +1,2 @@
+# renovate: datasource=github-releases depName=NousResearch/hermes-agent
+ref: v2026.4.30


### PR DESCRIPTION
## Summary
- New `containers/hermes-agent/` build for [NousResearch/hermes-agent](https://github.com/NousResearch/hermes-agent) — multi-stage Dockerfile on Python 3.14 + Node 24 + uv on Debian trixie-slim, with Playwright Chromium runtime libs.
- GHA workflow follows the existing `bird` / `opentakserver` pattern: BuildKit + GHA cache, pushes `:latest` and `:${ref}` to `ghcr.io/layertwo/hermes-agent`, cosign-signs on non-PR.
- Upstream tag pinned in `version.yaml` and tracked by the existing Renovate `github-releases` custom-manager.

No cluster manifests yet — that's a follow-up PR once the image builds clean.

## Test plan
- [ ] CI workflow runs on this PR and produces an image without pushing
- [ ] Merge to `mainline`, verify `:latest` and `:v2026.4.30` are pushed to GHCR
- [ ] Verify cosign signature on the published image
- [ ] Pull image on a node, confirm `hermes --help` runs as UID 10000
- [ ] Confirm Renovate opens a PR when upstream tags a newer release