### PR TITLE
feat: add kube-vip control-plane VIP for k3s HA

### DIFF
--- a/clusters/home/apps/kube-system/kube-vip/release.yml
+++ b/clusters/home/apps/kube-system/kube-vip/release.yml
@@ -1,0 +1,38 @@
+---
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: kube-vip
+  namespace: kube-system
+spec:
+  interval: 30m
+  chart:
+    spec:
+      chart: kube-vip
+      version: 0.9.9
+      sourceRef:
+        kind: HelmRepository
+        name: kube-vip
+        namespace: flux-system
+  install:
+    remediation:
+      retries: 3
+  upgrade:
+    cleanupOnFail: true
+    remediation:
+      strategy: rollback
+      retries: 3
+  values:
+    config:
+      address: 172.31.0.19
+    env:
+      vip_interface: eno1
+      cp_enable: "true"
+      cp_namespace: kube-system
+      svc_enable: "false"
+      lb_enable: "false"
+      vip_arp: "true"
+      vip_leaderelection: "true"
+      port: "6443"
+    nodeSelector:
+      node-role.kubernetes.io/control-plane: "true"

--- a/clusters/home/charts/helm/kube-vip.yml
+++ b/clusters/home/charts/helm/kube-vip.yml
@@ -1,0 +1,9 @@
+---
+apiVersion: source.toolkit.fluxcd.io/v1
+kind: HelmRepository
+metadata:
+  name: kube-vip
+  namespace: flux-system
+spec:
+  interval: 2h
+  url: https://kube-vip.github.io/helm-charts


### PR DESCRIPTION
## Summary
- Add kube-vip (control-plane-only, ARP mode) providing a floating VIP `172.31.0.19` for the k3s API server across the 3-node HA control plane
- MetalLB is untouched — `svc_enable`/`lb_enable` are disabled so kube-vip only manages the control-plane VIP, not Services

## Prerequisites (already done, out of band)
- All 3 control-plane nodes (`172.31.0.10-12`) already have `172.31.0.19` in their TLS SAN list, applied live via `k3sup`
- `bootstrap/plan.sh`/`bootstrap.sh` updated locally so a future from-scratch rebuild bakes this in (untracked, not part of this PR)

## Test plan
- [ ] Flux reconciles the HelmRelease successfully in `kube-system`
- [ ] kube-vip pod is `Running` on whichever control-plane node holds leadership
- [ ] `172.31.0.19:6443` responds and presents a valid cert
- [ ] Failover: cordon/drain the leader node, confirm the VIP moves to another control-plane node