### PR TITLE
feat(flux): add GitHub commit status reporting for flux-system Kustomization

### DIFF
--- a/clusters/home/flux-system/kustomization.yaml
+++ b/clusters/home/flux-system/kustomization.yaml
@@ -3,3 +3,5 @@ kind: Kustomization
 resources:
 - gotk-components.yaml
 - gotk-sync.yaml
+- secrets-github-commit-status.sops.yml
+- notifications.yml

--- a/clusters/home/flux-system/notifications.yml
+++ b/clusters/home/flux-system/notifications.yml
@@ -1,0 +1,22 @@
+apiVersion: notification.toolkit.fluxcd.io/v1beta3
+kind: Provider
+metadata:
+  name: github-commit-status
+  namespace: flux-system
+spec:
+  type: github
+  address: https://github.com/layertwo/homelab
+  secretRef:
+    name: github-commit-status
+---
+apiVersion: notification.toolkit.fluxcd.io/v1beta3
+kind: Alert
+metadata:
+  name: github-commit-status
+  namespace: flux-system
+spec:
+  providerRef:
+    name: github-commit-status
+  eventSources:
+    - kind: Kustomization
+      name: flux-system

--- a/clusters/home/flux-system/secrets-github-commit-status.sops.yml
+++ b/clusters/home/flux-system/secrets-github-commit-status.sops.yml
@@ -1,0 +1,23 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: github-commit-status
+  namespace: flux-system
+type: Opaque
+stringData:
+  token: ENC[AES256_GCM,data:Bwv0cM7rUyiE7Y2PCCuHGybpHNQaI8YNSzuupOsoTtMbV76y4Slt4PMCD1ftN5M6sZCntYwJf4yevGQvjTCInL841Cd7o+iJnGSAsU0NAIC2Z349kIzlCBYahOD5,iv:9bhUUqkUN9eKUoJe7cxzUFKQpe9Jn12xayKnT0t/tXE=,tag:4D5AztzRRiEObzO1OO2YlQ==,type:str]
+sops:
+  age:
+    - enc: |
+        -----BEGIN AGE ENCRYPTED FILE-----
+        YWdlLWVuY3J5cHRpb24ub3JnL3YxCi0+IFgyNTUxOSBreGN2a3BzZHJoSHd4b0tP
+        MmhRcHhvRnl0U2xjM1U4Sk1ZOEhUUjZKT0NnCjBWTDF1Yzhpa3I5QkNzL2hYYWJO
+        VityMkxaclAvRDg2cTV6ZjhTV28wblkKLS0tIGtSSmpJV0Z1OHNST2Z4bFdEUGZY
+        Mm40MWd4dis1VFlTend3QXhoSGp4N00K7i1O26G9xasO+9AiUwxIuj1J7lY++uBi
+        dNFl6RiTj2mM3U5LJqw8erTpnt+s8TdUTZjAIXp98JDwMYqvozjkgQ==
+        -----END AGE ENCRYPTED FILE-----
+      recipient: age140p5gj8xeqccpu283eycwhq7kwjrwug9emmj5mucn4j80jjzfd6qsnuv3y
+  encrypted_regex: ^(data|stringData)$
+  lastmodified: "2026-07-10T05:18:42Z"
+  mac: ENC[AES256_GCM,data:0uplgEjkiher1BcVLj5HMeCNsWV+nERqbWGnziCCIiH1tAjOKq7CpLKFavFAwmgGD8MEMvh7OyxQ6ynHUUrsnYbDQj5skL43SPPKiO0lV6z1yJEWfMBbUTng6U00Y0hLyQldPb+AvpovVauc/5OgYdz/PDnTWmLNrqtrnJRd9z8=,iv:6/UaBoH/kWeQ+1kMTc3AHu5HzfdIxNmJZoAMdqVmGEM=,tag:2Sw0znA4qAAxTBw/m18HRw==,type:str]
+  version: 3.13.2


### PR DESCRIPTION
## Summary
- Adds a `notification.toolkit.fluxcd.io/v1beta3` `Provider` (type `github`) + `Alert` so Flux posts a commit status to GitHub whenever the top-level `flux-system` Kustomization reconciles
- Wires the new manifest into `clusters/home/flux-system/kustomization.yaml`
- Adds a SOPS-encrypted `Secret` holding a repo-scoped GitHub fine-grained PAT (Commit statuses: Read and write) for `notification-controller` to authenticate with

## Test plan
- [x] `kubectl apply --dry-run=server -f clusters/home/flux-system/notifications.yml` — validated against live CRD schema, no errors
- [x] `kubectl kustomize clusters/home/flux-system` — builds cleanly, both `Provider` and `Alert` present
- [ ] After merge: `flux get kustomizations flux-system` shows a successful reconcile and the commit shows a GitHub status check